### PR TITLE
(feat) Imported latest changes from the official repo v8.2.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,31 @@ Ref: https://keepachangelog.com/en/1.0.0/
 
 # Changelog
 
+## [[Unreleased]]
+
+### Dependencies
+
+### API Breaking
+
+### State Machine Breaking
+
+### Improvements
+
+### Features
+
+### Bug Fixes
+
+## [v8.2.1](https://github.com/cosmos/ibc-go/releases/tag/v8.2.1) - 2024-04-25
+
+### Improvements
+
+* (apps/27-interchain-accounts) [\#6142](https://github.com/cosmos/ibc-go/pull/6142) Emit an event signalling that the host submodule is disabled.
+
+### Bug Fixes
+
+* [\#5837](https://github.com/cosmos/ibc-go/pull/5837) Move 02-client legacy v1beta gov types deprecation message to constructor functions.
+* (apps/transfer) [\#5497](https://github.com/cosmos/ibc-go/pull/5497) Fix text in log of the migration that sets the total amount of source chain tokens in escrow.
+
 ## [v8.2.0](https://github.com/cosmos/ibc-go/releases/tag/v8.2.0) - 2024-04-05
 
 ### Dependencies

--- a/modules/apps/27-interchain-accounts/host/ibc_module.go
+++ b/modules/apps/27-interchain-accounts/host/ibc_module.go
@@ -119,6 +119,7 @@ func (im IBCModule) OnRecvPacket(
 	logger := im.keeper.Logger(ctx)
 	if !im.keeper.GetParams(ctx).HostEnabled {
 		logger.Info("host submodule is disabled")
+		keeper.EmitHostDisabledEvent(ctx, packet)
 		return channeltypes.NewErrorAcknowledgement(types.ErrHostSubModuleDisabled)
 	}
 

--- a/modules/apps/27-interchain-accounts/host/keeper/events.go
+++ b/modules/apps/27-interchain-accounts/host/keeper/events.go
@@ -5,7 +5,9 @@ import (
 
 	sdk "github.com/cosmos/cosmos-sdk/types"
 
+	"github.com/cosmos/ibc-go/v8/modules/apps/27-interchain-accounts/host/types"
 	icatypes "github.com/cosmos/ibc-go/v8/modules/apps/27-interchain-accounts/types"
+	channeltypes "github.com/cosmos/ibc-go/v8/modules/core/04-channel/types"
 	"github.com/cosmos/ibc-go/v8/modules/core/exported"
 )
 
@@ -26,6 +28,19 @@ func EmitAcknowledgementEvent(ctx sdk.Context, packet exported.PacketI, ack expo
 		sdk.NewEvent(
 			icatypes.EventTypePacket,
 			attributes...,
+		),
+	)
+}
+
+// EmitHostDisabledEvent emits an event signalling that the host submodule is disabled.
+func EmitHostDisabledEvent(ctx sdk.Context, packet channeltypes.Packet) {
+	ctx.EventManager().EmitEvent(
+		sdk.NewEvent(
+			icatypes.EventTypePacket,
+			sdk.NewAttribute(sdk.AttributeKeyModule, icatypes.ModuleName),
+			sdk.NewAttribute(icatypes.AttributeKeyHostChannelID, packet.GetDestChannel()),
+			sdk.NewAttribute(icatypes.AttributeKeyAckError, types.ErrHostSubModuleDisabled.Error()),
+			sdk.NewAttribute(icatypes.AttributeKeyAckSuccess, "false"),
 		),
 	)
 }

--- a/modules/apps/transfer/keeper/migrations.go
+++ b/modules/apps/transfer/keeper/migrations.go
@@ -98,7 +98,7 @@ func (m Migrator) MigrateTotalEscrowForDenom(ctx sdk.Context) error {
 		m.keeper.SetTotalEscrowForDenom(ctx, totalEscrow)
 	}
 
-	m.keeper.Logger(ctx).Info("successfully set total escrow for %d denominations", totalEscrowed.Len())
+	m.keeper.Logger(ctx).Info("successfully set total escrow", "number of denominations", totalEscrowed.Len())
 	return nil
 }
 

--- a/modules/apps/transfer/types/msgs.go
+++ b/modules/apps/transfer/types/msgs.go
@@ -4,6 +4,7 @@ import (
 	"strings"
 
 	errorsmod "cosmossdk.io/errors"
+
 	sdk "github.com/cosmos/cosmos-sdk/types"
 
 	clienttypes "github.com/cosmos/ibc-go/v8/modules/core/02-client/types"

--- a/modules/core/02-client/types/legacy_proposal.go
+++ b/modules/core/02-client/types/legacy_proposal.go
@@ -1,5 +1,3 @@
-// Deprecated: The legacy v1beta1 gov types maintained in this file are deprecated and will be removed in a future release.
-// Please use MsgIBCSoftwareUpgrade and MsgRecoverClient in favour of the legacy v1beta1 gov proposal types.
 package types
 
 import (
@@ -34,6 +32,9 @@ func init() {
 }
 
 // NewClientUpdateProposal creates a new client update proposal.
+//
+// Deprecated: The legacy v1beta1 gov ClientUpdateProposal is deprecated
+// and will be removed in a future release. Please use MsgRecoverClient instead.
 func NewClientUpdateProposal(title, description, subjectClientID, substituteClientID string) govtypes.Content {
 	return &ClientUpdateProposal{
 		Title:              title,
@@ -76,6 +77,9 @@ func (cup *ClientUpdateProposal) ValidateBasic() error {
 }
 
 // NewUpgradeProposal creates a new IBC breaking upgrade proposal.
+//
+// Deprecated: The legacy v1beta1 gov UpgradeProposal is deprecated
+// and will be removed in a future release. Please use MsgIBCSoftwareUpgrade instead.
 func NewUpgradeProposal(title, description string, plan upgradetypes.Plan, upgradedClientState exported.ClientState) (govtypes.Content, error) {
 	clientAny, err := PackClientState(upgradedClientState)
 	if err != nil {


### PR DESCRIPTION
- Imported latest changes from the official repo v8.2.1
- This will help solve the lint error in chain core due to the deprecation message that was included at the module level in `"github.com/cosmos/ibc-go/v8/modules/core/02-client/types`